### PR TITLE
Remove arrow func to prevent syntax error on ie11

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -44,7 +44,9 @@ export default {
     },
     textStyle: {
       type: Object,
-      default: () => {}
+      default: function () {
+        return {}
+      }
     },
     color: {
       type: String,


### PR DESCRIPTION
This is in response to
https://github.com/biigpongsatorn/vue-element-loading/issues/19

I'm sure there is a configuration setting in bili that will solve this,
but, this is such a simple fix, it may be the best way to go.

I verified that this works on IE11 using browserling. 